### PR TITLE
Fallback to default apiExmaple parsing if not a path

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,10 +34,12 @@ function parserExampleElements(elements, element, block, filename) {
 	elements.pop();
 
 	const values = elementParser.parse(element.content, element.source);
-	app.log.debug('apiexample.path',values.path);
-	if (schemas[values.schema]) {
-		const data = fs.readFileSync( path.join(path.dirname(filename), values.path), 'utf8').toString();
-		element = schemas[values.schema](data, values.element, values.title);
+	if(values)
+		app.log.debug('apiexample.path',values.path);
+		if (schemas[values.schema]) {
+			const data = fs.readFileSync( path.join(path.dirname(filename), values.path), 'utf8').toString();
+			element = schemas[values.schema](data, values.element, values.title);
+		}
 	}
 	elements.push(element);
 	return elements;

--- a/index.js
+++ b/index.js
@@ -33,13 +33,11 @@ function parserExampleElements(elements, element, block, filename) {
 	if ( element.name !== 'apiexample' ) { return elements; }
 	elements.pop();
 
-	const values = elementParser.parse(element.content, element.source);
-	if(values)
+	const values = elementParser.parse(element.content, element.source);	
+	if (values && schemas[values.schema]) {
 		app.log.debug('apiexample.path',values.path);
-		if (schemas[values.schema]) {
-			const data = fs.readFileSync( path.join(path.dirname(filename), values.path), 'utf8').toString();
-			element = schemas[values.schema](data, values.element, values.title);
-		}
+		const data = fs.readFileSync( path.join(path.dirname(filename), values.path), 'utf8').toString();
+		element = schemas[values.schema](data, values.element, values.title);
 	}
 	elements.push(element);
 	return elements;


### PR DESCRIPTION
Both versions of @apiExample should work
```
/**
 * @api {get} /user/:id
 * @apiExample {curl} Example usage:
 *     curl -i http://localhost/user/4711
 */
```
and
```
/**
 * @api {get} /api GetAPI
 * @apiExample {json=./ex/api.req.json} apiParamExample Request
 */
```