### PR TITLE
Support other plugins using the @apiExample element

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,15 +35,15 @@ function parserExampleElements(elements, element, block, filename) {
 		return elements;
 	}
 
-	const parts = elementParser.parse(element.content, element.source);
-	if (!parts) {
+	const values = elementParser.parse(element.content, element.source);
+	if (!values) {
 		return elements
 	}
 
-	app.log.debug('apiexample.path', parts.path);
-	const data = fs.readFileSync(path.join(path.dirname(filename), parts.path), 'utf8').toString();
+	app.log.debug('apiexample.path', values.path);
+	const data = fs.readFileSync(path.join(path.dirname(filename), values.path), 'utf8').toString();
 
-	element = schemas[parts.schema](data, parts.element, parts.title);
+	element = schemas[values.schema](data, values.element, values.title);
 	elements.pop()
 	elements.push(element);
 

--- a/index.js
+++ b/index.js
@@ -30,15 +30,22 @@ function parserExampleElement(elements, element, block, filename) {
 }
 
 function parserExampleElements(elements, element, block, filename) {
-	if ( element.name !== 'apiexample' ) { return elements; }
-	elements.pop();
 
-	const values = elementParser.parse(element.content, element.source);	
-	if (values && schemas[values.schema]) {
-		app.log.debug('apiexample.path',values.path);
-		const data = fs.readFileSync( path.join(path.dirname(filename), values.path), 'utf8').toString();
-		element = schemas[values.schema](data, values.element, values.title);
+	if ( element.name !== 'apiexample' ) {
+		return elements;
 	}
+
+	const parts = elementParser.parse(element.content, element.source);
+	if (!parts) {
+		return elements
+	}
+
+	app.log.debug('apiexample.path', parts.path);
+	const data = fs.readFileSync(path.join(path.dirname(filename), parts.path), 'utf8').toString();
+
+	element = schemas[parts.schema](data, parts.element, parts.title);
+	elements.pop()
 	elements.push(element);
+
 	return elements;
 }

--- a/parser/api_example.js
+++ b/parser/api_example.js
@@ -7,7 +7,7 @@ function parse(content) {
 		return null;
 	
 	// @apiExample {json=relative_path} additional_argument
-	var parseRegExp = /^\{(.+?)=(.+?)\}\s*(?:\s+(.+?))?\s(.+?)$/g;
+	var parseRegExp = /^\{\s*(json|jsonschema|xml)\s*=(.+?)\}\s*(?:\s+(.+?))?\s(.+?)$/g;
 	var matches = parseRegExp.exec(content);
 
 	if ( ! matches)


### PR DESCRIPTION
**Stricter pattern matching**

Previously this plugin would catch all elements with the pattern:
```
@apiExample .*
``` 

This PR makes sure that `apidoc-plugin-example` only runs if the element matches any of these 3 patterns
```
@apiExample {json=.*
@apiExample {jsonschema=.*
@apiExample {xml=.*
```

Full regex here
`/^\s*\{(json|jsonschema|xml)\s*=(.+?)\}\s*(?:\s+(.+?))?\s(.+?)$/g;`


**Bugfix**

PR fixes a bug mentioned in #4, which happened because the plugin did not check if regex-match returned `null` before running `.pop()` and `.push()`. As an example, this would crash the `apidoc` command if `apiExample {curl}` was used together with plugin.

Further with the stricter pattern-matching mentioned above, we can remove an `if`-statement because we can trust parsed values more. 
```js
function parserExampleElements(elements, element, block, filename) {

  if ( element.name !== 'apiexample' ) {
    return elements;
  }

  const values = elementParser.parse(element.content, element.source);
  if (!values) {
    return elements
  }

  const data = fs.readFileSync(path.join(path.dirname(filename), values.path), 'utf8').toString();

  element = schemas[values.schema](data, values.element, values.title);
  elements.pop()
  elements.push(element);

  return elements;
}
```
Also we now make sure to run `.pop()` and `.push()` right next to each other, as the program will be in an inconsistent state if only one of them runs.